### PR TITLE
Alpine Linux base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM fedora:latest
+FROM alpine:3.5
 
 LABEL io.openshift.s2i.scripts-url=image:///usr/local/s2i
 
-RUN dnf install -y nginx && \
-    dnf clean all && \
+RUN apk add --no-cache nginx && \
     mkdir -m 0770 /nginx && \
     mkdir -m 0770 /nginx/conf.d && \
     mkdir -m 0770 /nginx/html && \

--- a/s2i/assemble
+++ b/s2i/assemble
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 echo "---> Installing configuration..."
 cp -Rf /tmp/src/conf.d/*.conf /nginx/conf.d/

--- a/s2i/run
+++ b/s2i/run
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 exec nginx -c /nginx/nginx.conf


### PR DESCRIPTION
To allow better usage on OpenShift Online (slow pulls and limited storage space), I ported the dockerfile to Alpine Linux instead of Fedora. Result is ~6MB image instead of ~260MB which makes building and pulling on OpenShift much faster.